### PR TITLE
fix: remove '/api' prefix from backend API endpoints

### DIFF
--- a/packages/mentora-api/src/lib/api/assignments.ts
+++ b/packages/mentora-api/src/lib/api/assignments.ts
@@ -44,7 +44,7 @@ export async function listCourseAssignments(
 		params.set('limit', options.limit.toString());
 	}
 
-	const result = await callBackend<unknown[]>(config, `/api/assignments?${params}`);
+	const result = await callBackend<unknown[]>(config, `/assignments?${params}`);
 	if (!result.success) {
 		return result;
 	}
@@ -68,7 +68,7 @@ export async function listAvailableAssignments(
 		params.set('limit', options.limit.toString());
 	}
 
-	const result = await callBackend<unknown[]>(config, `/api/assignments?${params}`);
+	const result = await callBackend<unknown[]>(config, `/assignments?${params}`);
 	if (!result.success) {
 		return result;
 	}

--- a/packages/mentora-api/src/lib/api/conversations.ts
+++ b/packages/mentora-api/src/lib/api/conversations.ts
@@ -136,7 +136,7 @@ export async function createConversation(
 	config: MentoraAPIConfig,
 	assignmentId: string
 ): Promise<APIResult<{ id: string }>> {
-	return callBackend(config, '/api/conversations', {
+	return callBackend(config, '/conversations', {
 		method: 'POST',
 		body: JSON.stringify({ assignmentId })
 	});
@@ -151,7 +151,7 @@ export async function endConversation(
 	config: MentoraAPIConfig,
 	conversationId: string
 ): Promise<APIResult<void>> {
-	return callBackend(config, `/api/conversations/${conversationId}/end`, {
+	return callBackend(config, `/conversations/${conversationId}/end`, {
 		method: 'POST'
 	});
 }
@@ -170,7 +170,7 @@ export async function addTurn(
 	text: string,
 	type: 'idea' | 'followup'
 ): Promise<APIResult<void>> {
-	return callBackend(config, `/api/conversations/${conversationId}/turns`, {
+	return callBackend(config, `/conversations/${conversationId}/turns`, {
 		method: 'POST',
 		body: JSON.stringify({ text, type })
 	});

--- a/packages/mentora-api/src/lib/api/courses.ts
+++ b/packages/mentora-api/src/lib/api/courses.ts
@@ -154,7 +154,7 @@ export async function createCourse(
 	options?: CreateCourseOptions
 ): Promise<APIResult<string>> {
 	// Use callBackend for consistent error handling and auth
-	const result = await callBackend<{ id: string }>(config, '/api/courses', {
+	const result = await callBackend<{ id: string }>(config, '/courses', {
 		method: 'POST',
 		body: JSON.stringify({
 			title,
@@ -456,7 +456,7 @@ export async function copyCourse(
 	}
 ): Promise<APIResult<string>> {
 	// Use callBackend
-	const result = await callBackend<{ id: string }>(config, `/api/courses/${courseId}/copy`, {
+	const result = await callBackend<{ id: string }>(config, `/courses/${courseId}/copy`, {
 		method: 'POST',
 		body: JSON.stringify(options)
 	});
@@ -511,7 +511,7 @@ export async function joinByCode(
 	config: MentoraAPIConfig,
 	code: string
 ): Promise<APIResult<JoinCourseResult>> {
-	return callBackend<JoinCourseResult>(config, '/api/courses/join', {
+	return callBackend<JoinCourseResult>(config, '/courses/join', {
 		method: 'POST',
 		body: JSON.stringify({ code })
 	});

--- a/packages/mentora-api/src/lib/api/topics.ts
+++ b/packages/mentora-api/src/lib/api/topics.ts
@@ -56,7 +56,7 @@ export async function listCourseTopics(
 		params.set('limit', options.limit.toString());
 	}
 
-	const result = await callBackend<unknown[]>(config, `/api/topics?${params}`);
+	const result = await callBackend<unknown[]>(config, `/topics?${params}`);
 	if (!result.success) {
 		return result;
 	}

--- a/packages/mentora-api/src/lib/api/wallets.ts
+++ b/packages/mentora-api/src/lib/api/wallets.ts
@@ -200,7 +200,7 @@ export async function addCredits(
 	amount: number,
 	currency: string = 'usd'
 ): Promise<APIResult<{ id: string }>> {
-	return callBackend<{ id: string }>(config, '/api/wallets', {
+	return callBackend<{ id: string }>(config, '/wallets', {
 		method: 'POST',
 		body: JSON.stringify({
 			action: 'addCredits',

--- a/packages/mentora-api/tests/backend.test.ts
+++ b/packages/mentora-api/tests/backend.test.ts
@@ -36,7 +36,7 @@ describe('Backend Module (Integration)', () => {
 
 	describe('callBackend()', () => {
 		it('should return success for health check', async () => {
-			const result = await callBackend<unknown>(config, '/api/health');
+			const result = await callBackend<unknown>(config, '/health');
 			expect(result.success).toBe(true);
 		});
 	});

--- a/packages/mentora-api/tests/emulator-setup.ts
+++ b/packages/mentora-api/tests/emulator-setup.ts
@@ -32,7 +32,7 @@ const firebaseConfig = {
 };
 
 // Backend URL (use dev server by default)
-export const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5173';
+export const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5173/api';
 
 // Firebase app instances for each role
 let teacherApp: FirebaseApp | null = null;


### PR DESCRIPTION
Updated all API calls in the mentora-api package to remove the '/api' prefix from endpoint URLs for assignments, conversations, courses, topics, wallets, and health check. Adjusted tests and emulator setup to match the new endpoint structure.