### PR TITLE
feat: Separate questionnaire questions from responses by introducing …

### DIFF
--- a/packages/firebase/src/firestore/questionnaires.ts
+++ b/packages/firebase/src/firestore/questionnaires.ts
@@ -14,16 +14,20 @@ const zSingleChoiceQuestion = z
             .min(1)
             .max(100)
             .describe("Answer options for single answer choice question."),
+    })
+    .describe("Single answer choice question.");
+
+const zSignalChiceResponse = z
+    .object({
+        type: z.literal("single_answer_choice"),
         response: z
             .string()
             .min(1)
             .max(500)
-            .nullable()
             .optional()
-            .default(null)
             .describe("The selected answer option."),
     })
-    .describe("Single answer choice question.");
+    .describe("Single answer choice response.");
 
 const zMultipleChoiceQuestion = z
     .object({
@@ -38,14 +42,17 @@ const zMultipleChoiceQuestion = z
             .min(1)
             .max(100)
             .describe("Answer options for multiple answer choice question."),
-        response: z
-            .array(z.string().min(1).max(500))
-            .nullable()
-            .optional()
-            .default(null)
-            .describe("The selected answer options."),
     })
     .describe("Multiple answer choice question.");
+
+const zMultipleChoiceResponse = z
+    .object({
+        type: z.literal("multiple_answer_choice"),
+        response: z
+            .array(z.string().min(1).max(500))
+            .describe("The selected answer options."),
+    })
+    .describe("Multiple answer choice response.");
 
 const zShortAnswerQuestion = z
     .object({
@@ -55,16 +62,19 @@ const zShortAnswerQuestion = z
             .min(1)
             .max(5000)
             .describe("The text of the question."),
+    })
+    .describe("Short answer question.");
+
+const zShortAnswerResponse = z
+    .object({
+        type: z.literal("short_answer"),
         response: z
             .string()
             .min(1)
             .max(5000)
-            .nullable()
-            .optional()
-            .default(null)
             .describe("The short answer response."),
     })
-    .describe("Short answer question.");
+    .describe("The short answer response.");
 
 const zSliderAnswerQuestion = z
     .object({
@@ -87,14 +97,15 @@ const zSliderAnswerQuestion = z
         minValue: z.number().describe("Minimum value of the slider."),
         maxValue: z.number().describe("Maximum value of the slider."),
         step: z.number().positive().describe("Step value for the slider."),
-        response: z
-            .number()
-            .nullable()
-            .optional()
-            .default(null)
-            .describe("The selected slider value."),
     })
     .describe("Slider answer question.");
+
+const zSliderAnswerResponse = z
+    .object({
+        type: z.literal("slider_answer"),
+        response: z.number().describe("The selected slider value."),
+    })
+    .describe("The selected slider value.");
 
 const zQuestion = z.object({
     question: z
@@ -106,6 +117,18 @@ const zQuestion = z.object({
         ])
         .describe("Question in the questionnaire."),
     required: z.boolean().describe("Indicates if the question is required."),
+});
+
+const zResponse = z.object({
+    questionId: z.string().describe("ID of the question."),
+    response: z
+        .union([
+            zSignalChiceResponse,
+            zMultipleChoiceResponse,
+            zShortAnswerResponse,
+            zSliderAnswerResponse,
+        ])
+        .describe("Response to the question."),
 });
 
 export const zQuestionnaire = z
@@ -143,6 +166,13 @@ export const zQuestionnaire = z
             .min(1)
             .max(100)
             .describe("List of questions in the questionnaire."),
+        responses: z
+            .array(zResponse)
+            .min(1)
+            .max(100)
+            .nullable()
+            .default(null)
+            .describe("List of responses to the questionnaire."),
         startAt: zFirebaseTimestamp.describe(
             "When the questionnaire becomes available.",
         ),

--- a/packages/firebase/tests/questionnaires.test.ts
+++ b/packages/firebase/tests/questionnaires.test.ts
@@ -35,11 +35,11 @@ function createQuestionnaireData(overrides: Record<string, unknown> = {}) {
                     type: "single_answer_choice",
                     questionText: "What is your favorite color?",
                     options: ["Red", "Blue", "Green"],
-                    response: null,
                 },
                 required: true,
             },
         ],
+        responses: null,
         startAt: Date.now(),
         dueAt: null,
         allowLate: false,
@@ -922,7 +922,6 @@ describe("Questionnaires Security Rules", () => {
                                         type: "multiple_answer_choice",
                                         questionText: "Select all that apply",
                                         options: ["A", "B", "C", "D"],
-                                        response: null,
                                     },
                                     required: true,
                                 },
@@ -952,7 +951,6 @@ describe("Questionnaires Security Rules", () => {
                                         type: "short_answer",
                                         questionText:
                                             "Describe your experience",
-                                        response: null,
                                     },
                                     required: false,
                                 },
@@ -986,7 +984,6 @@ describe("Questionnaires Security Rules", () => {
                                         minValue: 1,
                                         maxValue: 10,
                                         step: 1,
-                                        response: null,
                                     },
                                     required: true,
                                 },
@@ -1020,7 +1017,6 @@ describe("Questionnaires Security Rules", () => {
                                             "Teacher",
                                             "Admin",
                                         ],
-                                        response: null,
                                     },
                                     required: true,
                                 },
@@ -1035,7 +1031,6 @@ describe("Questionnaires Security Rules", () => {
                                             "History",
                                             "Art",
                                         ],
-                                        response: null,
                                     },
                                     required: false,
                                 },
@@ -1044,7 +1039,6 @@ describe("Questionnaires Security Rules", () => {
                                         type: "short_answer",
                                         questionText:
                                             "Any additional comments?",
-                                        response: null,
                                     },
                                     required: false,
                                 },
@@ -1058,7 +1052,1018 @@ describe("Questionnaires Security Rules", () => {
                                         minValue: 0,
                                         maxValue: 10,
                                         step: 1,
-                                        response: null,
+                                    },
+                                    required: true,
+                                },
+                            ],
+                        }),
+                    ),
+            );
+        });
+    });
+});
+
+describe("Questionnaires Security Rules", () => {
+    describe("Read Access", () => {
+        it("should allow course members to read course-bound questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const courseId = "course456";
+            const studentId = "student789";
+            const db = testEnv.authenticatedContext(studentId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const fs = context.firestore();
+                await fs.collection("courses").doc(courseId).set({
+                    id: courseId,
+                    title: "Test Course",
+                    code: "ABC123",
+                    ownerId: "owner999",
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                });
+                await fs
+                    .collection("courses")
+                    .doc(courseId)
+                    .collection("roster")
+                    .doc(studentId)
+                    .set({
+                        userId: studentId,
+                        email: "student@example.com",
+                        role: "student",
+                        status: "active",
+                        joinedAt: Date.now(),
+                    });
+                await fs
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: courseId,
+                            createdBy: "instructor123",
+                        }),
+                    );
+            });
+
+            await assertSucceeds(
+                db.collection("questionnaires").doc(questionnaireId).get(),
+            );
+        });
+
+        it("should allow creator to read standalone questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const creatorId = "creator456";
+            const db = testEnv.authenticatedContext(creatorId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                await context
+                    .firestore()
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: null,
+                            createdBy: creatorId,
+                        }),
+                    );
+            });
+
+            await assertSucceeds(
+                db.collection("questionnaires").doc(questionnaireId).get(),
+            );
+        });
+
+        it("should deny non-members from reading course-bound questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const courseId = "course456";
+            const nonMemberId = "nonmember999";
+            const db = testEnv.authenticatedContext(nonMemberId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const fs = context.firestore();
+                await fs.collection("courses").doc(courseId).set({
+                    id: courseId,
+                    title: "Test Course",
+                    code: "ABC123",
+                    ownerId: "owner999",
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                });
+                await fs
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: courseId,
+                            createdBy: "instructor123",
+                        }),
+                    );
+            });
+
+            await assertFails(
+                db.collection("questionnaires").doc(questionnaireId).get(),
+            );
+        });
+
+        it("should deny non-creators from reading standalone questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const creatorId = "creator456";
+            const otherUserId = "other789";
+            const db = testEnv.authenticatedContext(otherUserId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                await context
+                    .firestore()
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: null,
+                            createdBy: creatorId,
+                        }),
+                    );
+            });
+
+            await assertFails(
+                db.collection("questionnaires").doc(questionnaireId).get(),
+            );
+        });
+
+        it("should deny unauthenticated users from reading questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const db = testEnv.unauthenticatedContext().firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                await context
+                    .firestore()
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(createQuestionnaireData());
+            });
+
+            await assertFails(
+                db.collection("questionnaires").doc(questionnaireId).get(),
+            );
+        });
+
+        it("should allow querying questionnaires by courseId for course members", async () => {
+            const courseId = "course456";
+            const studentId = "student789";
+            const db = testEnv.authenticatedContext(studentId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const fs = context.firestore();
+                await fs.collection("courses").doc(courseId).set({
+                    id: courseId,
+                    title: "Test Course",
+                    code: "ABC123",
+                    ownerId: "owner999",
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                });
+                await fs
+                    .collection("courses")
+                    .doc(courseId)
+                    .collection("roster")
+                    .doc(studentId)
+                    .set({
+                        userId: studentId,
+                        email: "student@example.com",
+                        role: "student",
+                        status: "active",
+                        joinedAt: Date.now(),
+                    });
+                await fs
+                    .collection("questionnaires")
+                    .doc("q1")
+                    .set(
+                        createQuestionnaireData({
+                            id: "q1",
+                            courseId: courseId,
+                            createdBy: "instructor123",
+                        }),
+                    );
+            });
+
+            const result = await assertSucceeds(
+                db
+                    .collection("questionnaires")
+                    .where("courseId", "==", courseId)
+                    .get(),
+            );
+            expect(result.size).toBe(1);
+        });
+
+        it("should allow querying questionnaires by createdBy for standalone", async () => {
+            const creatorId = "creator456";
+            const db = testEnv.authenticatedContext(creatorId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                await context
+                    .firestore()
+                    .collection("questionnaires")
+                    .doc("q1")
+                    .set(
+                        createQuestionnaireData({
+                            id: "q1",
+                            courseId: null,
+                            createdBy: creatorId,
+                        }),
+                    );
+            });
+
+            const result = await assertSucceeds(
+                db
+                    .collection("questionnaires")
+                    .where("createdBy", "==", creatorId)
+                    .get(),
+            );
+            expect(result.size).toBe(1);
+        });
+    });
+
+    describe("Create Access", () => {
+        it("should allow instructors to create course-bound questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const courseId = "course456";
+            const instructorId = "instructor789";
+            const db = testEnv.authenticatedContext(instructorId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const fs = context.firestore();
+                await fs.collection("courses").doc(courseId).set({
+                    id: courseId,
+                    title: "Test Course",
+                    code: "ABC123",
+                    ownerId: "owner999",
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                });
+                await fs
+                    .collection("courses")
+                    .doc(courseId)
+                    .collection("roster")
+                    .doc(instructorId)
+                    .set({
+                        userId: instructorId,
+                        email: "instructor@example.com",
+                        role: "instructor",
+                        status: "active",
+                        joinedAt: Date.now(),
+                    });
+            });
+
+            await assertSucceeds(
+                db
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: courseId,
+                            createdBy: instructorId,
+                        }),
+                    ),
+            );
+        });
+
+        it("should allow TAs to create course-bound questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const courseId = "course456";
+            const taId = "ta789";
+            const db = testEnv.authenticatedContext(taId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const fs = context.firestore();
+                await fs.collection("courses").doc(courseId).set({
+                    id: courseId,
+                    title: "Test Course",
+                    code: "ABC123",
+                    ownerId: "owner999",
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                });
+                await fs
+                    .collection("courses")
+                    .doc(courseId)
+                    .collection("roster")
+                    .doc(taId)
+                    .set({
+                        userId: taId,
+                        email: "ta@example.com",
+                        role: "ta",
+                        status: "active",
+                        joinedAt: Date.now(),
+                    });
+            });
+
+            await assertSucceeds(
+                db
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: courseId,
+                            createdBy: taId,
+                        }),
+                    ),
+            );
+        });
+
+        it("should allow course owner to create course-bound questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const courseId = "course456";
+            const ownerId = "owner999";
+            const db = testEnv.authenticatedContext(ownerId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const fs = context.firestore();
+                await fs.collection("courses").doc(courseId).set({
+                    id: courseId,
+                    title: "Test Course",
+                    code: "ABC123",
+                    ownerId: ownerId,
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                });
+            });
+
+            await assertSucceeds(
+                db
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: courseId,
+                            createdBy: ownerId,
+                        }),
+                    ),
+            );
+        });
+
+        it("should allow users to create standalone questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const userId = "user456";
+            const db = testEnv.authenticatedContext(userId).firestore();
+
+            await assertSucceeds(
+                db
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: null,
+                            createdBy: userId,
+                        }),
+                    ),
+            );
+        });
+
+        it("should deny students from creating course-bound questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const courseId = "course456";
+            const studentId = "student789";
+            const db = testEnv.authenticatedContext(studentId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const fs = context.firestore();
+                await fs.collection("courses").doc(courseId).set({
+                    id: courseId,
+                    title: "Test Course",
+                    code: "ABC123",
+                    ownerId: "owner999",
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                });
+                await fs
+                    .collection("courses")
+                    .doc(courseId)
+                    .collection("roster")
+                    .doc(studentId)
+                    .set({
+                        userId: studentId,
+                        email: "student@example.com",
+                        role: "student",
+                        status: "active",
+                        joinedAt: Date.now(),
+                    });
+            });
+
+            await assertFails(
+                db
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: courseId,
+                            createdBy: studentId,
+                        }),
+                    ),
+            );
+        });
+
+        it("should deny creating standalone questionnaires with mismatched createdBy", async () => {
+            const questionnaireId = "questionnaire123";
+            const userId = "user456";
+            const db = testEnv.authenticatedContext(userId).firestore();
+
+            await assertFails(
+                db
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: null,
+                            createdBy: "someoneElse",
+                        }),
+                    ),
+            );
+        });
+
+        it("should deny unauthenticated users from creating questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const db = testEnv.unauthenticatedContext().firestore();
+
+            await assertFails(
+                db
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(createQuestionnaireData()),
+            );
+        });
+
+        it("should deny creating questionnaire with invalid data", async () => {
+            const questionnaireId = "questionnaire123";
+            const userId = "user456";
+            const db = testEnv.authenticatedContext(userId).firestore();
+
+            // Missing required questions field
+            await assertFails(
+                db.collection("questionnaires").doc(questionnaireId).set({
+                    id: questionnaireId,
+                    courseId: null,
+                    title: "Test",
+                    // questions missing
+                    startAt: Date.now(),
+                    dueAt: null,
+                    allowLate: false,
+                    allowResubmit: false,
+                    createdBy: userId,
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                }),
+            );
+        });
+
+        it("should deny creating questionnaire with empty questions array", async () => {
+            const questionnaireId = "questionnaire123";
+            const userId = "user456";
+            const db = testEnv.authenticatedContext(userId).firestore();
+
+            await assertFails(
+                db
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: null,
+                            createdBy: userId,
+                            questions: [],
+                        }),
+                    ),
+            );
+        });
+
+        it("should deny creating questionnaire with title too short", async () => {
+            const questionnaireId = "questionnaire123";
+            const userId = "user456";
+            const db = testEnv.authenticatedContext(userId).firestore();
+
+            await assertFails(
+                db
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: null,
+                            createdBy: userId,
+                            title: "",
+                        }),
+                    ),
+            );
+        });
+
+        it("should deny creating questionnaire with id too short", async () => {
+            const userId = "user456";
+            const db = testEnv.authenticatedContext(userId).firestore();
+
+            await assertFails(
+                db
+                    .collection("questionnaires")
+                    .doc("abc")
+                    .set(
+                        createQuestionnaireData({
+                            id: "abc", // less than 6 chars
+                            courseId: null,
+                            createdBy: userId,
+                        }),
+                    ),
+            );
+        });
+    });
+
+    describe("Update Access", () => {
+        it("should allow instructors to update course-bound questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const courseId = "course456";
+            const instructorId = "instructor789";
+            const db = testEnv.authenticatedContext(instructorId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const fs = context.firestore();
+                await fs.collection("courses").doc(courseId).set({
+                    id: courseId,
+                    title: "Test Course",
+                    code: "ABC123",
+                    ownerId: "owner999",
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                });
+                await fs
+                    .collection("courses")
+                    .doc(courseId)
+                    .collection("roster")
+                    .doc(instructorId)
+                    .set({
+                        userId: instructorId,
+                        email: "instructor@example.com",
+                        role: "instructor",
+                        status: "active",
+                        joinedAt: Date.now(),
+                    });
+                await fs
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: courseId,
+                            createdBy: "originalCreator",
+                        }),
+                    );
+            });
+
+            await assertSucceeds(
+                db.collection("questionnaires").doc(questionnaireId).update({
+                    title: "Updated Questionnaire Title",
+                    updatedAt: Date.now(),
+                }),
+            );
+        });
+
+        it("should allow creator to update standalone questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const creatorId = "creator456";
+            const db = testEnv.authenticatedContext(creatorId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                await context
+                    .firestore()
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: null,
+                            createdBy: creatorId,
+                        }),
+                    );
+            });
+
+            await assertSucceeds(
+                db.collection("questionnaires").doc(questionnaireId).update({
+                    title: "Updated Questionnaire Title",
+                    updatedAt: Date.now(),
+                }),
+            );
+        });
+
+        it("should deny students from updating course-bound questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const courseId = "course456";
+            const studentId = "student789";
+            const db = testEnv.authenticatedContext(studentId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const fs = context.firestore();
+                await fs.collection("courses").doc(courseId).set({
+                    id: courseId,
+                    title: "Test Course",
+                    code: "ABC123",
+                    ownerId: "owner999",
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                });
+                await fs
+                    .collection("courses")
+                    .doc(courseId)
+                    .collection("roster")
+                    .doc(studentId)
+                    .set({
+                        userId: studentId,
+                        email: "student@example.com",
+                        role: "student",
+                        status: "active",
+                        joinedAt: Date.now(),
+                    });
+                await fs
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: courseId,
+                            createdBy: "instructor123",
+                        }),
+                    );
+            });
+
+            await assertFails(
+                db.collection("questionnaires").doc(questionnaireId).update({
+                    title: "Hacked Title",
+                    updatedAt: Date.now(),
+                }),
+            );
+        });
+
+        it("should deny non-creators from updating standalone questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const creatorId = "creator456";
+            const otherUserId = "other789";
+            const db = testEnv.authenticatedContext(otherUserId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                await context
+                    .firestore()
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: null,
+                            createdBy: creatorId,
+                        }),
+                    );
+            });
+
+            await assertFails(
+                db.collection("questionnaires").doc(questionnaireId).update({
+                    title: "Hacked Title",
+                    updatedAt: Date.now(),
+                }),
+            );
+        });
+
+        it("should deny unauthenticated users from updating questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const db = testEnv.unauthenticatedContext().firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                await context
+                    .firestore()
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(createQuestionnaireData());
+            });
+
+            await assertFails(
+                db.collection("questionnaires").doc(questionnaireId).update({
+                    title: "Updated Title",
+                    updatedAt: Date.now(),
+                }),
+            );
+        });
+    });
+
+    describe("Delete Access", () => {
+        it("should allow instructors to delete course-bound questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const courseId = "course456";
+            const instructorId = "instructor789";
+            const db = testEnv.authenticatedContext(instructorId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const fs = context.firestore();
+                await fs.collection("courses").doc(courseId).set({
+                    id: courseId,
+                    title: "Test Course",
+                    code: "ABC123",
+                    ownerId: "owner999",
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                });
+                await fs
+                    .collection("courses")
+                    .doc(courseId)
+                    .collection("roster")
+                    .doc(instructorId)
+                    .set({
+                        userId: instructorId,
+                        email: "instructor@example.com",
+                        role: "instructor",
+                        status: "active",
+                        joinedAt: Date.now(),
+                    });
+                await fs
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: courseId,
+                            createdBy: "originalCreator",
+                        }),
+                    );
+            });
+
+            await assertSucceeds(
+                db.collection("questionnaires").doc(questionnaireId).delete(),
+            );
+        });
+
+        it("should allow creator to delete standalone questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const creatorId = "creator456";
+            const db = testEnv.authenticatedContext(creatorId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                await context
+                    .firestore()
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: null,
+                            createdBy: creatorId,
+                        }),
+                    );
+            });
+
+            await assertSucceeds(
+                db.collection("questionnaires").doc(questionnaireId).delete(),
+            );
+        });
+
+        it("should deny students from deleting course-bound questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const courseId = "course456";
+            const studentId = "student789";
+            const db = testEnv.authenticatedContext(studentId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const fs = context.firestore();
+                await fs.collection("courses").doc(courseId).set({
+                    id: courseId,
+                    title: "Test Course",
+                    code: "ABC123",
+                    ownerId: "owner999",
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                });
+                await fs
+                    .collection("courses")
+                    .doc(courseId)
+                    .collection("roster")
+                    .doc(studentId)
+                    .set({
+                        userId: studentId,
+                        email: "student@example.com",
+                        role: "student",
+                        status: "active",
+                        joinedAt: Date.now(),
+                    });
+                await fs
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: courseId,
+                            createdBy: "instructor123",
+                        }),
+                    );
+            });
+
+            await assertFails(
+                db.collection("questionnaires").doc(questionnaireId).delete(),
+            );
+        });
+
+        it("should deny non-creators from deleting standalone questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const creatorId = "creator456";
+            const otherUserId = "other789";
+            const db = testEnv.authenticatedContext(otherUserId).firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                await context
+                    .firestore()
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: null,
+                            createdBy: creatorId,
+                        }),
+                    );
+            });
+
+            await assertFails(
+                db.collection("questionnaires").doc(questionnaireId).delete(),
+            );
+        });
+
+        it("should deny unauthenticated users from deleting questionnaires", async () => {
+            const questionnaireId = "questionnaire123";
+            const db = testEnv.unauthenticatedContext().firestore();
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                await context
+                    .firestore()
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(createQuestionnaireData());
+            });
+
+            await assertFails(
+                db.collection("questionnaires").doc(questionnaireId).delete(),
+            );
+        });
+    });
+
+    describe("Question Types Validation", () => {
+        it("should allow creating questionnaire with multiple choice question", async () => {
+            const questionnaireId = "questionnaire123";
+            const userId = "user456";
+            const db = testEnv.authenticatedContext(userId).firestore();
+
+            await assertSucceeds(
+                db
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: null,
+                            createdBy: userId,
+                            questions: [
+                                {
+                                    question: {
+                                        type: "multiple_answer_choice",
+                                        questionText: "Select all that apply",
+                                        options: ["A", "B", "C", "D"],
+                                    },
+                                    required: true,
+                                },
+                            ],
+                        }),
+                    ),
+            );
+        });
+
+        it("should allow creating questionnaire with short answer question", async () => {
+            const questionnaireId = "questionnaire123";
+            const userId = "user456";
+            const db = testEnv.authenticatedContext(userId).firestore();
+
+            await assertSucceeds(
+                db
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: null,
+                            createdBy: userId,
+                            questions: [
+                                {
+                                    question: {
+                                        type: "short_answer",
+                                        questionText:
+                                            "Describe your experience",
+                                    },
+                                    required: false,
+                                },
+                            ],
+                        }),
+                    ),
+            );
+        });
+
+        it("should allow creating questionnaire with slider question", async () => {
+            const questionnaireId = "questionnaire123";
+            const userId = "user456";
+            const db = testEnv.authenticatedContext(userId).firestore();
+
+            await assertSucceeds(
+                db
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: null,
+                            createdBy: userId,
+                            questions: [
+                                {
+                                    question: {
+                                        type: "slider_answer",
+                                        questionText: "Rate your satisfaction",
+                                        minLabel: "Very Unsatisfied",
+                                        maxLabel: "Very Satisfied",
+                                        minValue: 1,
+                                        maxValue: 10,
+                                        step: 1,
+                                    },
+                                    required: true,
+                                },
+                            ],
+                        }),
+                    ),
+            );
+        });
+
+        it("should allow creating questionnaire with mixed question types", async () => {
+            const questionnaireId = "questionnaire123";
+            const userId = "user456";
+            const db = testEnv.authenticatedContext(userId).firestore();
+
+            await assertSucceeds(
+                db
+                    .collection("questionnaires")
+                    .doc(questionnaireId)
+                    .set(
+                        createQuestionnaireData({
+                            id: questionnaireId,
+                            courseId: null,
+                            createdBy: userId,
+                            questions: [
+                                {
+                                    question: {
+                                        type: "single_answer_choice",
+                                        questionText: "What is your role?",
+                                        options: [
+                                            "Student",
+                                            "Teacher",
+                                            "Admin",
+                                        ],
+                                    },
+                                    required: true,
+                                },
+                                {
+                                    question: {
+                                        type: "multiple_answer_choice",
+                                        questionText:
+                                            "Which topics interest you?",
+                                        options: [
+                                            "Math",
+                                            "Science",
+                                            "History",
+                                            "Art",
+                                        ],
+                                    },
+                                    required: false,
+                                },
+                                {
+                                    question: {
+                                        type: "short_answer",
+                                        questionText:
+                                            "Any additional comments?",
+                                    },
+                                    required: false,
+                                },
+                                {
+                                    question: {
+                                        type: "slider_answer",
+                                        questionText:
+                                            "How likely would you recommend us?",
+                                        minLabel: "Not at all",
+                                        maxLabel: "Definitely",
+                                        minValue: 0,
+                                        maxValue: 10,
+                                        step: 1,
                                     },
                                     required: true,
                                 },

--- a/packages/mentora-api/src/lib/api/client.ts
+++ b/packages/mentora-api/src/lib/api/client.ts
@@ -286,6 +286,13 @@ export class MentoraClient {
 		delete: (questionnaireId: string): Promise<APIResult<void>> =>
 			this.authReadyThen(() =>
 				QuestionnairesModule.deleteQuestionnaire(this._config, questionnaireId)
+			),
+		submitResponse: (
+			questionnaireId: string,
+			responses: Questionnaire['responses']
+		): Promise<APIResult<void>> =>
+			this.authReadyThen(() =>
+				QuestionnairesModule.submitResponse(this._config, questionnaireId, responses)
 			)
 	};
 

--- a/packages/mentora-api/src/lib/api/questionnaires.ts
+++ b/packages/mentora-api/src/lib/api/questionnaires.ts
@@ -150,3 +150,21 @@ export async function deleteQuestionnaire(
 		await deleteDoc(docRef);
 	});
 }
+
+/**
+ * Submit a response to a questionnaire
+ */
+export async function submitResponse(
+	config: MentoraAPIConfig,
+	questionnaireId: string,
+	responses: Questionnaire['responses']
+): Promise<APIResult<void>> {
+	return tryCatch(async () => {
+		const docRef = doc(config.db, Questionnaires.docPath(questionnaireId));
+
+		await updateDoc(docRef, {
+			responses,
+			updatedAt: Date.now()
+		});
+	});
+}


### PR DESCRIPTION
This pull request introduces a structured approach for handling questionnaire responses in the codebase. It defines new Zod schemas for different types of question responses, adds a unified `responses` field to the questionnaire schema, and implements API methods for submitting responses. These changes improve the clarity, type safety, and extensibility of questionnaire handling.

**Schema improvements for questionnaire responses:**

* Added new Zod schemas for single choice, multiple choice, short answer, and slider answer responses (`zSingleChoiceResponse`, `zMultipleChoiceResponse`, `zShortAnswerResponse`, `zSliderAnswerResponse`), each with a `type` discriminator for better type safety. [[1]](diffhunk://#diff-eb1e86a4856555db23f17b1325ed3ffd26db46bf3a7a240a2b54b283bf00d4c2R17-R30) [[2]](diffhunk://#diff-eb1e86a4856555db23f17b1325ed3ffd26db46bf3a7a240a2b54b283bf00d4c2R45-R55) [[3]](diffhunk://#diff-eb1e86a4856555db23f17b1325ed3ffd26db46bf3a7a240a2b54b283bf00d4c2R65-R77) [[4]](diffhunk://#diff-eb1e86a4856555db23f17b1325ed3ffd26db46bf3a7a240a2b54b283bf00d4c2L90-R109)
* Introduced a unified `zResponse` schema to encapsulate all response types and added a `responses` array field to the `zQuestionnaire` schema, allowing questionnaires to store structured responses. [[1]](diffhunk://#diff-eb1e86a4856555db23f17b1325ed3ffd26db46bf3a7a240a2b54b283bf00d4c2R122-R133) [[2]](diffhunk://#diff-eb1e86a4856555db23f17b1325ed3ffd26db46bf3a7a240a2b54b283bf00d4c2R169-R175)

**API enhancements:**

* Implemented a new `submitResponse` method in the `MentoraClient` class to allow submitting responses to questionnaires.
* Added the `submitResponse` function in the questionnaires API module to update questionnaire documents with new responses and a timestamp.…dedicated response schemas and a top-level responses array.