### PR TITLE
fix: ASR error handling and audio playback for AI responses

### DIFF
--- a/apps/mentora/src/routes/conversations/[id]/+page.svelte
+++ b/apps/mentora/src/routes/conversations/[id]/+page.svelte
@@ -526,6 +526,31 @@
         showKeywords = !showKeywords;
     }
 
+    function playBase64Audio(base64: string, mimeType: string = "audio/mp3") {
+        try {
+            const binary = atob(base64);
+            const bytes = new Uint8Array(binary.length);
+            for (let i = 0; i < binary.length; i++) {
+                bytes[i] = binary.charCodeAt(i);
+            }
+            const blob = new Blob([bytes], { type: mimeType });
+            const url = URL.createObjectURL(blob);
+            const audio = new Audio(url);
+            audio.addEventListener("ended", () => URL.revokeObjectURL(url), {
+                once: true,
+            });
+            audio.addEventListener("error", () => URL.revokeObjectURL(url), {
+                once: true,
+            });
+            audio.play().catch((e) => {
+                console.error("Audio playback failed:", e);
+                URL.revokeObjectURL(url);
+            });
+        } catch (e) {
+            console.error("Failed to play audio response:", e);
+        }
+    }
+
     async function handleRecordingComplete(blob: Blob) {
         if (!conversationId || isConversationClosed) return;
 
@@ -539,20 +564,9 @@
                     ? blob
                     : new Blob([blob], { type: "audio/webm" });
 
-            const formData = new FormData();
-            formData.set(
-                "audio",
+            const res = await api.conversations.addTurn(conversationId, {
                 audio,
-                `recording.${audio.type.includes("mp4") ? "mp4" : "webm"}`,
-            );
-
-            const res = await api.backend.call(
-                `/conversations/${conversationId}/turns`,
-                {
-                    method: "POST",
-                    body: formData,
-                },
-            );
+            });
 
             if (!res.success) {
                 console.error("Failed to add audio turn:", res.error);
@@ -562,6 +576,11 @@
                 sendError = detail
                     ? `${m.conversation_error()} ${detail}`
                     : m.conversation_error();
+            } else if (res.data?.audio) {
+                playBase64Audio(
+                    res.data.audio,
+                    res.data.audioMimeType || "audio/mp3",
+                );
             }
         } catch (e) {
             console.error("Error sending audio turn:", e);
@@ -605,6 +624,12 @@
             } else {
                 messageInput = "";
                 showTextInput = false;
+                if (res.data?.audio) {
+                    playBase64Audio(
+                        res.data.audio,
+                        res.data.audioMimeType || "audio/mp3",
+                    );
+                }
             }
         } catch (e) {
             console.error("Error sending message:", e);

--- a/packages/mentora-api/src/lib/server/application/conversation-service.ts
+++ b/packages/mentora-api/src/lib/server/application/conversation-service.ts
@@ -298,7 +298,8 @@ export class ConversationService {
 						usage: asrExecutor.getTokenUsage()
 					}
 				]);
-			} catch {
+			} catch (error) {
+				if (error instanceof Response) throw error;
 				throw errorResponse(
 					'Failed to transcribe audio. Please try again or use text input.',
 					HttpStatus.INTERNAL_SERVER_ERROR,

--- a/packages/mentora-api/tests/conversation-service-asr.unit.test.ts
+++ b/packages/mentora-api/tests/conversation-service-asr.unit.test.ts
@@ -133,7 +133,7 @@ async function extractResponseBody(response: Response): Promise<any> {
 }
 
 describe('ConversationService.addTurn – ASR error handling', () => {
-	const user = { uid: 'user-1' };
+	const user = { uid: 'user-1', email: 'test@example.com', emailVerified: true };
 
 	beforeEach(() => {
 		vi.restoreAllMocks();

--- a/packages/mentora-api/tests/conversation-service-asr.unit.test.ts
+++ b/packages/mentora-api/tests/conversation-service-asr.unit.test.ts
@@ -1,0 +1,216 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { ConversationService } from '../src/lib/server/application/conversation-service.js';
+import type { IConversationRepository } from '../src/lib/server/repositories/ports/conversation-repository.js';
+import type { IConversationLLMGateway } from '../src/lib/server/application/gateways/conversation-llm-gateway.js';
+
+// Mock executors module
+vi.mock('../src/lib/server/llm/executors.js', () => ({
+	EXECUTOR_MODEL: {
+		PROMPT: 'test-prompt',
+		ASR: 'test-asr',
+		CONTENT: 'test-content',
+		TTS: 'test-tts'
+	},
+	getASRExecutor: vi.fn(),
+	getTTSExecutor: vi.fn()
+}));
+
+import { getASRExecutor, getTTSExecutor } from '../src/lib/server/llm/executors.js';
+
+const mockedGetASRExecutor = vi.mocked(getASRExecutor);
+const mockedGetTTSExecutor = vi.mocked(getTTSExecutor);
+
+function createMockConversation() {
+	return {
+		assignmentId: 'assignment-1',
+		userId: 'user-1',
+		state: 'awaiting_idea' as const,
+		lastActionAt: Date.now(),
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		turns: [],
+		tokenUsage: null
+	};
+}
+
+function createMockAssignment() {
+	return {
+		id: 'assignment-1',
+		courseId: 'course-1',
+		topicId: null,
+		title: 'Test',
+		question: 'Test question',
+		prompt: 'Test prompt',
+		mode: 'instant' as const,
+		startAt: Date.now() - 10000,
+		dueAt: null,
+		allowLate: false,
+		allowResubmit: false,
+		createdBy: 'teacher-1',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		classReport: null
+	};
+}
+
+function createMockRepo(overrides?: Partial<IConversationRepository>): IConversationRepository {
+	return {
+		getConversation: vi.fn().mockResolvedValue(createMockConversation()),
+		getAssignment: vi.fn().mockResolvedValue(createMockAssignment()),
+		createConversation: vi.fn(),
+		updateConversation: vi.fn(),
+		deleteConversationState: vi.fn(),
+		getMembership: vi.fn(),
+		getSubmission: vi.fn().mockResolvedValue(null),
+		saveSubmission: vi.fn(),
+		appendTurns: vi.fn(),
+		...overrides
+	};
+}
+
+function createMockLLMGateway(): IConversationLLMGateway {
+	return {
+		process: vi.fn().mockResolvedValue({
+			aiMessage: 'AI response',
+			ended: false,
+			stanceSnapshot: null,
+			updatedState: {},
+			assessment: null,
+			assessmentError: null,
+			tokenUsage: {
+				cachedContentTokenCount: 0,
+				candidatesTokenCount: 10,
+				promptTokenCount: 5,
+				thoughtsTokenCount: 0,
+				toolUsePromptTokenCount: 0,
+				totalTokenCount: 15
+			}
+		}),
+		extractSummary: vi.fn().mockReturnValue({
+			stage: 'exploring',
+			currentStance: null,
+			currentPrinciple: null
+		})
+	};
+}
+
+function createMockASRExecutor(transcribeResult: string | Error) {
+	return {
+		resetTokenUsage: vi.fn(),
+		transcribe:
+			typeof transcribeResult === 'string'
+				? vi.fn().mockResolvedValue(transcribeResult)
+				: vi.fn().mockRejectedValue(transcribeResult),
+		getTokenUsage: vi.fn().mockReturnValue({
+			cachedContentTokenCount: 0,
+			candidatesTokenCount: 5,
+			promptTokenCount: 3,
+			thoughtsTokenCount: 0,
+			toolUsePromptTokenCount: 0,
+			totalTokenCount: 8
+		})
+	};
+}
+
+function createMockTTSExecutor() {
+	return {
+		resetTokenUsage: vi.fn(),
+		synthesize: vi.fn().mockResolvedValue('base64-audio-data'),
+		getTokenUsage: vi.fn().mockReturnValue({
+			cachedContentTokenCount: 0,
+			candidatesTokenCount: 10,
+			promptTokenCount: 5,
+			thoughtsTokenCount: 0,
+			toolUsePromptTokenCount: 0,
+			totalTokenCount: 15
+		})
+	};
+}
+
+async function extractResponseBody(response: Response): Promise<any> {
+	return JSON.parse(await response.text());
+}
+
+describe('ConversationService.addTurn – ASR error handling', () => {
+	const user = { uid: 'user-1' };
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('returns 400 "No speech detected" when transcription is empty', async () => {
+		const repo = createMockRepo();
+		const gateway = createMockLLMGateway();
+		const service = new ConversationService(repo, gateway);
+
+		// ASR returns empty/whitespace-only text
+		mockedGetASRExecutor.mockReturnValue(createMockASRExecutor('   ') as any);
+
+		try {
+			await service.addTurn(user, 'conv-1', {
+				audioBase64: 'dGVzdA==',
+				audioMimeType: 'audio/webm'
+			});
+			expect.unreachable('Should have thrown');
+		} catch (error) {
+			expect(error).toBeInstanceOf(Response);
+			const response = error as Response;
+			expect(response.status).toBe(400);
+			const body = await extractResponseBody(response);
+			expect(body.error).toContain('No speech detected');
+		}
+	});
+
+	it('returns 500 "Failed to transcribe" when ASR throws a non-Response error', async () => {
+		const repo = createMockRepo();
+		const gateway = createMockLLMGateway();
+		const service = new ConversationService(repo, gateway);
+
+		// ASR throws a regular Error (e.g., API failure)
+		mockedGetASRExecutor.mockReturnValue(
+			createMockASRExecutor(new Error('Gemini API connection failed')) as any
+		);
+
+		try {
+			await service.addTurn(user, 'conv-1', {
+				audioBase64: 'dGVzdA==',
+				audioMimeType: 'audio/webm'
+			});
+			expect.unreachable('Should have thrown');
+		} catch (error) {
+			expect(error).toBeInstanceOf(Response);
+			const response = error as Response;
+			expect(response.status).toBe(500);
+			const body = await extractResponseBody(response);
+			expect(body.error).toContain('Failed to transcribe audio');
+		}
+	});
+
+	it('processes audio successfully when ASR returns valid text', async () => {
+		const repo = createMockRepo();
+		const gateway = createMockLLMGateway();
+		const service = new ConversationService(repo, gateway);
+
+		mockedGetASRExecutor.mockReturnValue(createMockASRExecutor('Hello world') as any);
+		mockedGetTTSExecutor.mockReturnValue(createMockTTSExecutor() as any);
+
+		const result = await service.addTurn(user, 'conv-1', {
+			audioBase64: 'dGVzdA==',
+			audioMimeType: 'audio/webm'
+		});
+
+		expect(result.text).toBe('AI response');
+		expect(result.audio).toBe('base64-audio-data');
+		expect(result.audioMimeType).toBe('audio/mp3');
+
+		// Verify ASR was called with correct params
+		const asrExecutor = mockedGetASRExecutor.mock.results[0].value;
+		expect(asrExecutor.transcribe).toHaveBeenCalledWith('dGVzdA==', 'audio/webm');
+
+		// Verify LLM gateway received transcribed text
+		expect(gateway.process).toHaveBeenCalledWith(
+			expect.objectContaining({ userInputText: 'Hello world' })
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- Fix ASR catch block in `ConversationService.addTurn` that swallowed specific "No speech detected" (400) errors, replacing them with generic "Failed to transcribe" (500) errors
- Add `playBase64Audio()` to play AI TTS audio responses in the conversation page for both text and voice input flows
- Unify audio sending path to use `api.conversations.addTurn()` instead of raw `api.backend.call()`

## Test plan
- [x] Added unit tests for ASR error handling: empty transcription (400), API failure (500), success path
- [x] All existing tests pass (344 passed, 3 skipped)
- [x] Svelte type check passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)