### PR TITLE
fix(api): close conversation when dialogue stage reaches ended

### DIFF
--- a/packages/mentora-api/src/lib/server/application/conversation-service.ts
+++ b/packages/mentora-api/src/lib/server/application/conversation-service.ts
@@ -115,6 +115,10 @@ export class ConversationService {
 		userId: string,
 		assessmentData?: { assessment?: unknown; assessmentError?: string }
 	): Promise<void> {
+		console.log('[ConversationService:submitSubmission]', {
+			assignmentId: assignment.id,
+			userId
+		});
 		const existing = await this.conversationRepository.getSubmission(assignment.id, userId);
 		const submittedAt = Date.now();
 		ensureSubmissionWindow(assignment, submittedAt);
@@ -399,6 +403,16 @@ export class ConversationService {
 			throw error;
 		}
 
+		console.log(
+			'[ConversationService:addTurn] after processWithLLM (dialogue state already saved)',
+			{
+				conversationId,
+				assignmentId: assignment.id,
+				llmEnded: llmResult.ended,
+				dialogueStage: llmResult.updatedState.stage
+			}
+		);
+
 		llmUsageReport = createTokenUsageReport([
 			{
 				feature: TOKEN_USAGE_FEATURES.CONVERSATION_LLM,
@@ -435,6 +449,15 @@ export class ConversationService {
 					updatedAt: Date.now()
 				});
 			}
+			console.error(
+				'[ConversationService:addTurn] TTS failed after LLM (submission not updated yet)',
+				{
+					conversationId,
+					assignmentId: assignment.id,
+					llmEnded: llmResult.ended,
+					dialogueStage: llmResult.updatedState.stage
+				}
+			);
 			throw errorResponse(
 				'Failed to synthesize speech. Please try again.',
 				HttpStatus.INTERNAL_SERVER_ERROR,
@@ -474,11 +497,17 @@ export class ConversationService {
 				conversationId,
 				userId: user.uid,
 				turns: [userTurn, aiTurn],
-				ended: llmResult.ended,
 				finalNow,
 				usageReport: requestUsageReport
 			});
 		} catch (error) {
+			console.error('[ConversationService:addTurn] appendTurns failed', {
+				conversationId,
+				assignmentId: assignment.id,
+				llmEnded: llmResult.ended,
+				dialogueStage: llmResult.updatedState.stage,
+				error: error instanceof Error ? error.message : String(error)
+			});
 			if (error instanceof Error) {
 				if (error.message === 'Conversation not found') {
 					throw errorResponse(
@@ -504,6 +533,16 @@ export class ConversationService {
 			}
 			throw error;
 		}
+
+		console.log('[ConversationService:addTurn] after appendTurns', {
+			conversationId,
+			assignmentId: assignment.id,
+			llmEnded: llmResult.ended,
+			dialogueStage: llmResult.updatedState.stage,
+			stageEndedButNotClosed: llmResult.updatedState.stage === 'ended' && !llmResult.ended
+		});
+
+		const conversationShouldClose = llmResult.ended || llmResult.updatedState.stage === 'ended';
 
 		// Post-turn: calculate and record spend
 		const turnCostUsd = calculateReportCostUsd(
@@ -546,10 +585,22 @@ export class ConversationService {
 			}
 		}
 
-		if (llmResult.ended) {
+		if (conversationShouldClose) {
+			console.log('[ConversationService:addTurn] closing conversation + submitting', {
+				conversationId,
+				assignmentId: assignment.id,
+				llmEnded: llmResult.ended,
+				dialogueStage: llmResult.updatedState.stage
+			});
 			await this.submitSubmission(assignment, user.uid, {
 				assessment: llmResult.assessment ?? undefined,
 				assessmentError: llmResult.assessmentError
+			});
+			const closeNow = Date.now();
+			await this.conversationRepository.updateConversation(conversationId, {
+				state: 'closed',
+				lastActionAt: closeNow,
+				updatedAt: closeNow
 			});
 		}
 
@@ -561,7 +612,7 @@ export class ConversationService {
 			conversationId,
 			userTurnId,
 			aiTurnId,
-			conversationEnded: llmResult.ended,
+			conversationEnded: conversationShouldClose,
 			stage: summary.stage,
 			stance: summary.currentStance,
 			principle: summary.currentPrinciple,

--- a/packages/mentora-api/src/lib/server/llm/llm-service.ts
+++ b/packages/mentora-api/src/lib/server/llm/llm-service.ts
@@ -237,11 +237,27 @@ export async function processWithLLM(
 	// Step 4: Save updated state to Firestore (includes ownership validation)
 	await saveDialogueState(firestore, conversationId, userId, result.newState);
 
+	const endedFromHandler = result.ended;
+	const endedFromState = orchestrator.isEnded(result.newState);
+	const combinedEnded = endedFromHandler || endedFromState;
+	console.log('[MentoraLLM] processWithLLM outcome', {
+		conversationId,
+		stage: result.newState.stage,
+		resultEnded: endedFromHandler,
+		isEndedNewState: endedFromState,
+		combinedEnded
+	});
+	if (result.newState.stage === DialogueStage.ENDED && !combinedEnded) {
+		console.warn('[MentoraLLM] stage is ended but combined ended flag is false (unexpected)', {
+			conversationId
+		});
+	}
+
 	// Step 5: Return formatted result
 	return {
 		aiMessage: result.message,
 		updatedState: result.newState,
-		ended: result.ended || orchestrator.isEnded(result.newState),
+		ended: combinedEnded,
 		tokenUsage: usage,
 		assessment: result.assessment,
 		assessmentError: result.assessmentError,

--- a/packages/mentora-api/src/lib/server/repositories/firestore/conversation-repository.ts
+++ b/packages/mentora-api/src/lib/server/repositories/firestore/conversation-repository.ts
@@ -140,7 +140,6 @@ export class FirestoreConversationRepository implements IConversationRepository 
 		conversationId: string;
 		userId: string;
 		turns: Turn[];
-		ended: boolean;
 		finalNow: number;
 		usageReport: TokenUsageReport;
 	}): Promise<void> {
@@ -159,7 +158,6 @@ export class FirestoreConversationRepository implements IConversationRepository 
 				throw new Error('Conversation is closed');
 			}
 
-			const conversationState = params.ended ? 'closed' : latestConversation.state;
 			const conversationTokenUsage = toConversationTokenUsage(
 				latestConversation.tokenUsage,
 				params.usageReport,
@@ -168,7 +166,7 @@ export class FirestoreConversationRepository implements IConversationRepository 
 
 			transaction.update(conversationRef, {
 				turns: [...latestConversation.turns, ...params.turns],
-				state: conversationState,
+				state: latestConversation.state,
 				lastActionAt: params.finalNow,
 				updatedAt: params.finalNow,
 				tokenUsage: conversationTokenUsage

--- a/packages/mentora-api/src/lib/server/repositories/ports/conversation-repository.ts
+++ b/packages/mentora-api/src/lib/server/repositories/ports/conversation-repository.ts
@@ -25,7 +25,6 @@ export interface IConversationRepository {
 		conversationId: string;
 		userId: string;
 		turns: Turn[];
-		ended: boolean;
 		finalNow: number;
 		usageReport: TokenUsageReport;
 	}): Promise<void>;

--- a/packages/mentora-api/tests/conversation-service-asr.unit.test.ts
+++ b/packages/mentora-api/tests/conversation-service-asr.unit.test.ts
@@ -35,6 +35,22 @@ function createMockConversation() {
 	};
 }
 
+function createMockSubmission() {
+	return {
+		userId: 'user-1',
+		state: 'in_progress' as const,
+		startedAt: Date.now() - 1000,
+		submittedAt: null,
+		late: false,
+		scoreCompletion: null,
+		notes: null,
+		assessment: null,
+		assessmentError: null,
+		totalSpentUsd: 0,
+		budgetExhausted: false
+	};
+}
+
 function createMockAssignment() {
 	return {
 		id: 'assignment-1',
@@ -278,5 +294,113 @@ describe('ConversationService.addTurn – ASR error handling', () => {
 			expect.objectContaining({ apiKey: 'global-api-key', userInputText: 'Hello world' })
 		);
 		expect(mockedGetTTSExecutor).toHaveBeenCalledWith('global-api-key');
+	});
+});
+
+describe('ConversationService.addTurn – conversation completion', () => {
+	const user = { uid: 'user-1', email: 'test@example.com', emailVerified: true };
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('submits and closes the conversation when dialogue stage reaches ended even if ended flag is false', async () => {
+		const repo = createMockRepo({
+			getSubmission: vi.fn().mockResolvedValue(createMockSubmission())
+		});
+		const gateway = createMockLLMGateway();
+		vi.mocked(gateway.process).mockResolvedValue({
+			aiMessage: 'Final AI response',
+			ended: false,
+			stanceSnapshot: null,
+			updatedState: { stage: 'ended' },
+			assessment: {
+				dimensions: {
+					argumentQuality: { score: 4, feedback: 'Strong reasoning' },
+					criticalThinking: { score: 4, feedback: 'Thoughtful analysis' },
+					principleExtraction: { score: 4, feedback: 'Clear principle' },
+					openness: { score: 4, feedback: 'Shows openness' },
+					coherence: { score: 4, feedback: 'Well structured' }
+				},
+				overallScore: 4,
+				overallFeedback: 'Good work',
+				generatedAt: Date.now()
+			},
+			assessmentError: null,
+			tokenUsage: {
+				cachedContentTokenCount: 0,
+				candidatesTokenCount: 10,
+				promptTokenCount: 5,
+				thoughtsTokenCount: 0,
+				toolUsePromptTokenCount: 0,
+				totalTokenCount: 15
+			}
+		});
+		const service = new ConversationService(repo, gateway, createMockWalletRepo());
+
+		mockedGetTTSExecutor.mockReturnValue(createMockTTSExecutor() as any);
+
+		const result = await service.addTurn(user, 'conv-1', {
+			text: 'Here is my final answer'
+		});
+
+		expect(result.conversationEnded).toBe(true);
+		expect(repo.saveSubmission).toHaveBeenCalledWith(
+			'assignment-1',
+			'user-1',
+			expect.objectContaining({
+				state: 'submitted',
+				assessment: expect.objectContaining({
+					overallScore: 4,
+					overallFeedback: 'Good work'
+				}),
+				assessmentError: null
+			})
+		);
+		expect(repo.updateConversation).toHaveBeenCalledWith(
+			'conv-1',
+			expect.objectContaining({ state: 'closed' })
+		);
+	});
+
+	it('still reports completion when ended flag is true', async () => {
+		const repo = createMockRepo({
+			getSubmission: vi.fn().mockResolvedValue(createMockSubmission())
+		});
+		const gateway = createMockLLMGateway();
+		vi.mocked(gateway.process).mockResolvedValue({
+			aiMessage: 'Final AI response',
+			ended: true,
+			stanceSnapshot: null,
+			updatedState: { stage: 'adding_final_summary' },
+			assessment: null,
+			assessmentError: null,
+			tokenUsage: {
+				cachedContentTokenCount: 0,
+				candidatesTokenCount: 10,
+				promptTokenCount: 5,
+				thoughtsTokenCount: 0,
+				toolUsePromptTokenCount: 0,
+				totalTokenCount: 15
+			}
+		});
+		const service = new ConversationService(repo, gateway, createMockWalletRepo());
+
+		mockedGetTTSExecutor.mockReturnValue(createMockTTSExecutor() as any);
+
+		const result = await service.addTurn(user, 'conv-1', {
+			text: 'Wrap this up'
+		});
+
+		expect(result.conversationEnded).toBe(true);
+		expect(repo.saveSubmission).toHaveBeenCalledWith(
+			'assignment-1',
+			'user-1',
+			expect.objectContaining({ state: 'submitted' })
+		);
+		expect(repo.updateConversation).toHaveBeenCalledWith(
+			'conv-1',
+			expect.objectContaining({ state: 'closed' })
+		);
 	});
 });


### PR DESCRIPTION
The bug was in the conversation completion path. Previously, the backend only finalized a conversation when
  llmResult.ended === true. In some cases, the dialogue state had already advanced to updatedState.stage ===
  'ended', but the ended flag was still false. When that happened, the system failed to submit the linked
  submission and failed to mark the conversation as closed. As a result, Firestore could remain in a half-finished
  state with the submission still marked in_progress, which prevented the frontend from showing the analysis /
  assessment screen because the UI gates that view on conversation.state === 'closed'.

  The fix was to unify the completion condition so the backend now closes the conversation whenever either signal
  says the dialogue is finished: llmResult.ended || llmResult.updatedState.stage === 'ended'. I also added
  regression tests to cover the broken case where the stage is ended but the boolean flag is not, and to confirm
  the existing normal completion path still works.